### PR TITLE
improve list reasignment bug workaround

### DIFF
--- a/tamo/models/schedule.py
+++ b/tamo/models/schedule.py
@@ -77,7 +77,7 @@ class SchoolDay:
 
     """
 
-    def __init__(self, lessons=[], empty=False):
+    def __init__(self, lessons=None, empty=False):
         """
         Create a school day.
 
@@ -88,8 +88,18 @@ class SchoolDay:
 
         # We need to do this instead of simply assigning, because otherwise
         # every time we create such an object, it gets its previous values.
-        # I don't know why is this
-        self._lessons = lessons[:]
+        # ~~I don't know why is this~~
+
+        # Update: the reason is https://www.reddit.com/r/learnpython/comments/apsplq/what_are_some_bad_habits_to_avoid/egbgqnf/
+        # (last point). This was soooo frustrating for me. See commit
+        # history for what was the issue before
+        if lessons is None:
+            self._lessons = []
+        else:
+        # I don't know if I actually need this line, and according to
+        # the above linked reddit comment its not super clear,
+        # however I will still leave it in.
+            self._lessons = lessons[:]
 
         self.empty = empty
 


### PR DESCRIPTION
I just read a Reddit comment with bad practices, and one of those was
the annoying bug I was facing, that the lessons argument would start out
at its previous value when creating a new object. Now I kinda know why.

So I linked it in a comment, and improved the workaround a bit as
suggested by the comment.

However the part in the else statement is maybe needed, maybe not. The
comment didn't mention that as it said about only mutating, not copying.

So the else part still has the previous workaround.